### PR TITLE
Set temp YouTube statement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ environment.
 
 Start by selecting an example, opening and running it.
 
-Tutorial videos are available here: <<NEED LINK TO OUR VIDEOS>>
+D-Wave tutorial videos are available on YouTube.
 
 Developing Applications
 -----------------------


### PR DESCRIPTION
In case this gets into the SDK before we get the links (currently scheduled for Tuesday noon, so too late). If we get links in time we can update to something such as "D-Wave tutorial videos are available on YouTube, such as <link1>, <link2>."